### PR TITLE
migrate Gradle config to use to buildSrc convention plugins

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,49 +1,6 @@
-allprojects {
-  repositories {
-    mavenCentral()
-  }
-
-  group = "com.github.serras.kopykat"
-  version = "0.1"
+plugins {
+  buildsrc.conventions.`kopykat-base`
 }
 
-subprojects {
-  apply(plugin = "java-library")
-  apply(plugin = "maven-publish")
-
-  configure<PublishingExtension> {
-    publications {
-      create<MavenPublication>("maven") {
-        groupId = project.group as String
-        artifactId = project.name
-        version = project.version as String
-        from(components["java"])
-
-        pom {
-          description.set("Little utilities for more pleasant immutable data in Kotlin")
-          url.set("https://github.com/serras/kopykat")
-          licenses {
-
-          }
-          licenses {
-            license {
-              name.set("The Apache License, Version 2.0")
-              url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
-            }
-          }
-          developers {
-            developer {
-              id.set("kopykat-authors")
-              name.set("The KopyKat authors")
-            }
-          }
-          scm {
-            connection.set("scm:git:git://github.com/serras/kopykat.git")
-            developerConnection.set("scm:git:ssh://git@github.com/serras/kopykat.git")
-            url.set("https://github.com/serras/kopykat")
-          }
-        }
-      }
-    }
-  }
-}
+group = "com.github.serras.kopykat"
+version = "0.1"

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,40 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    `kotlin-dsl`
+    kotlin("jvm") version embeddedKotlinVersion
+}
+
+val gradleJvmTarget = "11"
+val gradleKotlinTarget = "1.6"
+
+val kotlinVersion = "1.7.10"
+
+dependencies {
+    implementation(platform(libs.kotlin.bom))
+
+    // Set the *Maven coordinates* of Gradle plugins here.
+    // This should be the only place where Gradle plugins versions are defined.
+
+    implementation(libs.gradlePlugin.kotlinJvm)
+}
+
+
+tasks.withType<KotlinCompile>().configureEach {
+    kotlinOptions {
+        jvmTarget = gradleJvmTarget
+        apiVersion = gradleKotlinTarget
+        languageVersion = gradleKotlinTarget
+    }
+}
+
+
+kotlin {
+    jvmToolchain {
+        (this as JavaToolchainSpec).languageVersion.set(JavaLanguageVersion.of(gradleJvmTarget))
+    }
+}
+
+kotlinDslPluginOptions {
+    jvmTarget.set(gradleJvmTarget)
+}

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -35,6 +35,7 @@ kotlin {
     }
 }
 
+
 kotlinDslPluginOptions {
     jvmTarget.set(gradleJvmTarget)
 }

--- a/buildSrc/repositories.settings.gradle.kts
+++ b/buildSrc/repositories.settings.gradle.kts
@@ -1,0 +1,24 @@
+// shared repository definitions for both the main project and buildSrc
+
+@Suppress("UnstableApiUsage") // Central declaration of repositories is an incubating feature
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
+
+    repositories {
+        mavenCentral()
+        jitpack()
+        gradlePluginPortal()
+    }
+
+    pluginManagement {
+        repositories {
+            gradlePluginPortal()
+            mavenCentral()
+            jitpack()
+        }
+    }
+}
+
+fun RepositoryHandler.jitpack() {
+    maven("https://jitpack.io")
+}

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,12 @@
+rootProject.name = "buildSrc"
+
+apply(from = "./repositories.settings.gradle.kts")
+
+@Suppress("UnstableApiUsage") // Central declaration of repositories is an incubating feature
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/buildsrc/conventions/kopykat-base.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/kopykat-base.gradle.kts
@@ -1,0 +1,12 @@
+package buildsrc.conventions
+
+plugins {
+    base
+}
+
+description = "Common config that can be used in all projects"
+
+if (project != rootProject) {
+    project.group = rootProject.group
+    project.version = rootProject.version
+}

--- a/buildSrc/src/main/kotlin/buildsrc/conventions/kotlin-jvm.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/kotlin-jvm.gradle.kts
@@ -1,0 +1,25 @@
+package buildsrc.conventions
+
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    id("buildsrc.conventions.kopykat-base")
+    kotlin("jvm")
+    `java-library`
+}
+
+dependencies {
+    implementation(platform(kotlin("bom")))
+}
+
+kotlin {
+    explicitApi()
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    kotlinOptions.jvmTarget = "1.8"
+}

--- a/buildSrc/src/main/kotlin/buildsrc/conventions/kotlin-jvm.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/kotlin-jvm.gradle.kts
@@ -14,6 +14,9 @@ dependencies {
 
 kotlin {
     explicitApi()
+    jvmToolchain {
+        languageVersion.set(JavaLanguageVersion.of("11"))
+    }
 }
 
 tasks.test {

--- a/buildSrc/src/main/kotlin/buildsrc/conventions/maven-publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildsrc/conventions/maven-publish.gradle.kts
@@ -1,0 +1,43 @@
+package buildsrc.conventions
+
+plugins {
+    `maven-publish`
+}
+
+publishing {
+    // configure all publications to have the same POM
+    publications.withType<MavenPublication>().configureEach {
+        pom {
+            description.set("Little utilities for more pleasant immutable data in Kotlin")
+            url.set("https://github.com/serras/kopykat")
+            licenses {
+                license {
+                    name.set("The Apache License, Version 2.0")
+                    url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                }
+            }
+            developers {
+                developer {
+                    id.set("kopykat-authors")
+                    name.set("The KopyKat authors")
+                }
+            }
+            scm {
+                connection.set("scm:git:git://github.com/serras/kopykat.git")
+                developerConnection.set("scm:git:ssh://git@github.com/serras/kopykat.git")
+                url.set("https://github.com/serras/kopykat")
+            }
+        }
+    }
+}
+
+plugins.withType<JavaPlugin>().configureEach {
+    // only create a 'java' publication when the JavaPlugin is present
+    publishing {
+        publications {
+            register<MavenPublication>("maven") {
+                from(components["java"])
+            }
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ assertj = "3.23.1"
 classgraph = "4.8.149"
 
 [libraries]
+kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
 kotlin-stdlibCommon = { module = "org.jetbrains.kotlin:kotlin-stdlib-common" }
 kotlin-stdlibJDK8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8" }
 kotlinPoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinPoet" }
@@ -17,6 +18,12 @@ kotlinCompileTestingKsp = { module = "com.github.tschuchortdev:kotlin-compile-te
 assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 classgraph = { module = "io.github.classgraph:classgraph", version.ref = "classgraph" }
 
+### Plugins ###
+# the *Maven coodinates* of Gradle plugins. Use in ./buildSrc/build.gradle.kts.
+
+gradlePlugin-kotlinJvm = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+
+
 [plugins]
-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-ksp = { id = "com.google.devtools.ksp", version.ref = "kspVersion" }
+
+# import plugins using Maven coordinates (see above), not the Gradle plugin ID

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,5 @@
+# https://jitpack.io/docs/BUILDING/
+
+# https://jitpack.io/docs/BUILDING/#java-version
+jdk:
+  - openjdk11

--- a/ksp/build.gradle.kts
+++ b/ksp/build.gradle.kts
@@ -1,12 +1,6 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
-@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
-    alias(libs.plugins.kotlin.jvm)
-}
-
-kotlin {
-    explicitApi()
+    buildsrc.conventions.`kotlin-jvm`
+    buildsrc.conventions.`maven-publish`
 }
 
 dependencies {
@@ -17,12 +11,4 @@ dependencies {
     testImplementation(kotlin("test"))
 
     testRuntimeOnly(projects.ksp)
-}
-
-tasks.test {
-    useJUnitPlatform()
-}
-
-tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,10 @@ enableFeaturePreview("VERSION_CATALOGS")
 
 rootProject.name = "kopykat"
 
-include(":ksp")
-include(":utils:compilation")
-include(":utils:kotlin-poet")
+apply(from = "./buildSrc/repositories.settings.gradle.kts")
+
+include(
+  ":ksp",
+  ":utils:compilation",
+  ":utils:kotlin-poet",
+)

--- a/utils/compilation/build.gradle.kts
+++ b/utils/compilation/build.gradle.kts
@@ -1,12 +1,8 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
-    alias(libs.plugins.kotlin.jvm)
-}
-
-kotlin {
-    explicitApi()
+    buildsrc.conventions.`kotlin-jvm`
+    buildsrc.conventions.`maven-publish`
 }
 
 dependencies {
@@ -24,8 +20,4 @@ dependencies {
         )
     }
     implementation(libs.kotlinCompileTestingKsp)
-}
-
-tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
 }

--- a/utils/kotlin-poet/build.gradle.kts
+++ b/utils/kotlin-poet/build.gradle.kts
@@ -1,20 +1,10 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
-@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
-    alias(libs.plugins.kotlin.jvm)
-}
-
-kotlin {
-    explicitApi()
+    buildsrc.conventions.`kotlin-jvm`
+    buildsrc.conventions.`maven-publish`
 }
 
 dependencies {
     implementation(libs.ksp)
     api(libs.kotlinPoet)
     api(libs.kotlinPoet.ksp)
-}
-
-tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
 }


### PR DESCRIPTION
Prep for #29 

* Created the buildSrc project
* Created a shared repository definition file, so it's easier to set the repositories available for buildSrc and the main project
* moved the common Kotlin configuration to `kotlin-jvm.gradle.kts`, and applied it to the subprojects
* the same for the Maven publishing config
* `libs.versions.toml` is still used to define versions - but Gradle plugins versions are now defined in `buildSrc/build.gradle.kts`. This is the only place the versions need to be defined - once they are, the plugins can be imported without a version in convention plugins, or build scripts (in fact Gradle will complain if the version is set again).
* bumped the JDK version to 11, and told JitPack to use JDK 11