### PR TITLE
Mutable utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,14 @@ val p5 = p1.copy { // mutates the job.teams collection in-place
 }
 ```
 
+The `at.kopyk:mutable-utils` library contains versions of the main collection functions which reuse the same structure.
+
+```kotlin
+val p6 = p1.copy { // mutates the job.teams collection in-place
+  job.teams.mapInPlace { it.capitalize() }
+}
+```
+
 ### Mapping `copyMap`
 
 Instead of new *values*, `copyMap` takes as arguments the *transformations* that ought to be applied to each argument.

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The `at.kopyk:mutable-utils` library contains versions of the main collection fu
 
 ```kotlin
 val p6 = p1.copy { // mutates the job.teams collection in-place
-  job.teams.mapInPlace { it.capitalize() }
+  job.teams.mutateAll { it.capitalize() }
 }
 ```
 

--- a/mutable-utils/build.gradle.kts
+++ b/mutable-utils/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    buildsrc.conventions.`kotlin-jvm`
+    buildsrc.conventions.`maven-publish`
+}

--- a/mutable-utils/src/main/kotlin/at/kopyk/MutableUtils.kt
+++ b/mutable-utils/src/main/kotlin/at/kopyk/MutableUtils.kt
@@ -1,0 +1,53 @@
+package at.kopyk
+
+/**
+ * Applies 'transform' to each element in the list,
+ * reusing the same structure to keep them.
+ */
+public fun <A> MutableList<A>.mapInPlace(
+  transform: (A) -> A
+): MutableList<A> {
+  forEachIndexed { ix, value ->
+    this[ix] = transform(value)
+  }
+  return this
+}
+
+/**
+ * Applies 'transform' to each element in the list,
+ * reusing the same structure to keep them.
+ */
+public fun <A> MutableList<A>.mapIndexedInPlace(
+  transform: (index: Int, value: A) -> A
+): MutableList<A> {
+  forEachIndexed { ix, value ->
+    this[ix] = transform(ix, value)
+  }
+  return this
+}
+
+/**
+ * Applies 'transform' to each value in the map,
+ * reusing the same structure to keep them.
+ */
+public fun <K, V> MutableMap<K, V>.mapValuesInPlace(
+  transform: (entry: Map.Entry<K, V>) -> V
+): MutableMap<K, V> {
+  forEach { entry ->
+    this[entry.key] = transform(entry)
+  }
+  return this
+}
+
+/**
+ * Applies 'transform' to each value in the map,
+ * reusing the same structure to keep them.
+ */
+public fun <K, V> MutableMap<K, V>.mapValuesInPlace(
+  transform: (key: K, value: V) -> V
+): MutableMap<K, V> {
+  forEach { (key, value) ->
+    this[key] = transform(key, value)
+  }
+  return this
+}

--- a/mutable-utils/src/main/kotlin/at/kopyk/MutableUtils.kt
+++ b/mutable-utils/src/main/kotlin/at/kopyk/MutableUtils.kt
@@ -4,7 +4,7 @@ package at.kopyk
  * Applies 'transform' to each element in the list,
  * reusing the same structure to keep them.
  */
-public fun <A> MutableList<A>.mapInPlace(
+public fun <A> MutableList<A>.mutateAll(
   transform: (A) -> A
 ): MutableList<A> {
   forEachIndexed { ix, value ->
@@ -17,7 +17,7 @@ public fun <A> MutableList<A>.mapInPlace(
  * Applies 'transform' to each element in the list,
  * reusing the same structure to keep them.
  */
-public fun <A> MutableList<A>.mapIndexedInPlace(
+public fun <A> MutableList<A>.mutateAllIndexed(
   transform: (index: Int, value: A) -> A
 ): MutableList<A> {
   forEachIndexed { ix, value ->
@@ -30,7 +30,7 @@ public fun <A> MutableList<A>.mapIndexedInPlace(
  * Applies 'transform' to each value in the map,
  * reusing the same structure to keep them.
  */
-public fun <K, V> MutableMap<K, V>.mapValuesInPlace(
+public fun <K, V> MutableMap<K, V>.mutateValues(
   transform: (entry: Map.Entry<K, V>) -> V
 ): MutableMap<K, V> {
   forEach { entry ->
@@ -43,7 +43,7 @@ public fun <K, V> MutableMap<K, V>.mapValuesInPlace(
  * Applies 'transform' to each value in the map,
  * reusing the same structure to keep them.
  */
-public fun <K, V> MutableMap<K, V>.mapValuesInPlace(
+public fun <K, V> MutableMap<K, V>.mutateValues(
   transform: (key: K, value: V) -> V
 ): MutableMap<K, V> {
   forEach { (key, value) ->

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,4 +9,5 @@ include(
   ":kopykat-ksp",
   ":utils:compiletesting",
   ":utils:kotlin-poet",
+  ":mutable-utils",
 )


### PR DESCRIPTION
These utilities should be useful in combination with the mutable `copy`. For example, if you want to `map` over a list, the developer would be forced to use `toMutableList` at the end to please the compiler. But now the can do:

```kotlin
person.copy {
  jobs.mapInPlace { it.capitalize() }
}
```