### PR TITLE
Use updated version of Apache Commons IO

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ kotlinPoet = "1.12.0"
 kotlinCompileTesting = "1.4.9"
 assertj = "3.23.1"
 classgraph = "4.8.149"
-commons = "1.3.2"
+commonsIo = "2.11.0"
 ktlint = "11.0.0"
 
 [libraries]
@@ -19,7 +19,7 @@ kotlinCompileTesting = { module = "com.github.tschuchortdev:kotlin-compile-testi
 kotlinCompileTestingKsp = { module = "com.github.tschuchortdev:kotlin-compile-testing-ksp", version.ref = "kotlinCompileTesting" }
 assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 classgraph = { module = "io.github.classgraph:classgraph", version.ref = "classgraph" }
-apache-commons-io = { module = "org.apache.commons:commons-io", version.ref = "commons"}
+apache-commons-io = { module = "commons-io:commons-io", version.ref = "commonsIo"}
 
 ### Plugins ###
 # the *Maven coodinates* of Gradle plugins. Use in ./buildSrc/build.gradle.kts.


### PR DESCRIPTION
It turns out that Commons IO changed from releasing under the [`org.apache.commons` group](https://central.sonatype.dev/artifact/org.apache.commons/commons-io/1.3.2) (latest version 1.3.2) to [`commons-io`](https://central.sonatype.dev/artifact/commons-io/commons-io/2.11.0) (actual latest version 2.11.0). This PR changes to the latter, which is important since the 1.x series has a known vulnaberability.