### PR TITLE
Keep nullability information in 'mutationInfo'

### DIFF
--- a/kopykat-ksp/src/main/kotlin/at/kopyk/utils/TypeCompileScope.kt
+++ b/kopykat-ksp/src/main/kotlin/at/kopyk/utils/TypeCompileScope.kt
@@ -33,7 +33,6 @@ internal data class MutationInfo<out T : TypeName>(
 )
 
 internal sealed interface TypeCompileScope : KSDeclaration {
-
   val logger: KSPLogger
   val typeVariableNames: List<TypeVariableName>
   val typeParameterResolver: TypeParameterResolver
@@ -169,10 +168,21 @@ internal class FileCompilerScope(
   }
 }
 
+/**
+ * Obtains the [ClassName] corresponding to a [KSType].
+ *
+ * We need this function because [KSType.toClassName] doesn't
+ * keep the nullability information correctly. As seen in
+ * issue #62, this meant that [String?] was for example mapped
+ * (incorrectly) to [String] when generating mutation info.
+ */
+internal fun KSType.toClassNameRespectingNullability(): ClassName =
+  toClassName().copy(this.isMarkedNullable, emptyList(), emptyMap())
+
 internal fun TypeCompileScope.mutationInfo(ty: KSType): MutationInfo<TypeName> =
   when (ty.declaration) {
     is KSClassDeclaration -> {
-      val className = ty.toClassName()
+      val className = ty.toClassNameRespectingNullability()
       val intermediate: MutationInfo<ClassName> = when {
         className == LIST ->
           MutationInfo(

--- a/kopykat-ksp/src/test/kotlin/at/kopyk/CopyMapTest.kt
+++ b/kopykat-ksp/src/test/kotlin/at/kopyk/CopyMapTest.kt
@@ -16,6 +16,17 @@ class CopyMapTest {
   }
 
   @Test
+  fun `simple test, nullable type`() {
+    """
+      |data class Person(val name: String, val age: Int?)
+      |
+      |val p1 = Person("Alex", 1)
+      |val p2 = p1.copyMap(age = { n -> n?.let { it + 1 } })
+      |val r = p2.age
+      """.evals("r" to 2)
+  }
+
+  @Test
   fun `simple test on nested class`() {
     """
       |class Things {

--- a/kopykat-ksp/src/test/kotlin/at/kopyk/MutableCopyTest.kt
+++ b/kopykat-ksp/src/test/kotlin/at/kopyk/MutableCopyTest.kt
@@ -29,6 +29,28 @@ class MutableCopyTest {
   }
 
   @Test
+  fun `mutate one property, nullable type`() {
+    """
+      |data class Person(val name: String, val age: Int?)
+      |
+      |val p1 = Person("Alex", 1)
+      |val p2 = p1.copy { age = age?.let { it + 1 } }
+      |val r = p2.age
+      """.evals("r" to 2)
+  }
+
+  @Test
+  fun `mutate one property, nullable type, set to null`() {
+    """
+      |data class Person(val name: String, val age: Int?)
+      |
+      |val p1 = Person("Alex", 1)
+      |val p2 = p1.copy { age = null }
+      |val r = p2.age
+      """.evals("r" to null)
+  }
+
+  @Test
   fun `mutate two properties`() {
     """
       |data class Person(val name: String, val age: Int)


### PR DESCRIPTION
Fixes #62

As @maxschlosser correctly identified in https://github.com/kopykat-kt/kopykat/issues/62#issuecomment-1276478384, the issue comes from not preserving nullability information when generating the "mutation info", that is, the mapping of properties that go into the `Class$Mutable` type generated as part of "mutable `copy`". It turns out that KSP's `KSType.toClassName` was not respecting this information, so the solution has been to hack own on `toClassNameRespectingNullability`.