### PR TITLE
Use the modifiers declared in the type

### DIFF
--- a/kopykat-ksp/src/main/kotlin/at/kopyk/CopyMap.kt
+++ b/kopykat-ksp/src/main/kotlin/at/kopyk/CopyMap.kt
@@ -16,12 +16,14 @@ import at.kopyk.utils.lang.mapRun
 import at.kopyk.utils.lang.onEachRun
 import at.kopyk.utils.typeCategory
 import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.ksp.toKModifier
 
 internal val TypeCompileScope.copyMapFunctionKt: FileSpec
   get() = buildFile(fileName = target.append("CopyMap").reflectionName()) {
     val parameterized = target.parameterized
     addGeneratedMarker()
     addInlinedFunction(name = "copyMap", receives = parameterized, returns = parameterized) {
+      visibility.toKModifier()?.let { addModifiers(it) }
       properties
         .onEachRun {
           addParameter(

--- a/kopykat-ksp/src/test/kotlin/at/kopyk/MutableCopyTest.kt
+++ b/kopykat-ksp/src/test/kotlin/at/kopyk/MutableCopyTest.kt
@@ -16,6 +16,17 @@ class MutableCopyTest {
   }
 
   @Test
+  fun `mutate one property, internal`() {
+    """
+      |internal data class Person(val name: String, val age: Int)
+      |
+      |internal val p1 = Person("Alex", 1)
+      |internal val p2 = p1.copy { age = age + 1 }
+      |val r = p2.age
+      """.evals("r" to 2)
+  }
+
+  @Test
   fun `weird package name, issue #78`() {
     """
       |package `this`.`in`.other


### PR DESCRIPTION
This PR fixes #85. Until now we were always creating `public` functions and types, with this change we use the same modifiers as were declared in the type (for example, if the type is `internal`, the `Mutable` type and `copy` functions are also `internal`).